### PR TITLE
Intra net

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ DNS              ?= no
 ACME             ?= no
 DCAPE_TAG        ?= dcape
 DCAPE_NET        ?= $(DCAPE_TAG)
+DCAPE_NET_INTRA  ?= intra
 DCAPE_DOMAIN     ?= dev.lan
 APPS_ALWAYS      ?= traefik narra enfist drone portainer
 TZ               ?= $(shell cat /etc/timezone)
@@ -19,6 +20,7 @@ PG_PORT_LOCAL    ?= 5433
 PG_SOURCE_SUFFIX ?=
 PG_SHM_SIZE      ?= 64mb
 DCAPE_SUBNET     ?= 100.127.0.0/24
+DCAPE_SUBNET_INTRA ?= 100.127.255.0/24
 DCAPE_VAR        ?= var
 DC_VER           ?= 1.27.4
 ENFIST_URL       ?= http://enfist:8080/rpc
@@ -62,6 +64,9 @@ AUTH_SERVER=$(AUTH_SERVER)
 # docker network name
 DCAPE_NET=$(DCAPE_NET)
 
+# docker internal network name
+DCAPE_NET_INTRA=$(DCAPE_NET_INTRA)
+
 # container(s) required for up in any case
 # used in make only
 APPS=$(APPS)
@@ -85,6 +90,9 @@ PG_SHM_SIZE=$(PG_SHM_SIZE)
 
 # docker network subnet
 DCAPE_SUBNET=$(DCAPE_SUBNET)
+
+# docker intra network subnet
+DCAPE_SUBNET_INTRA=$(DCAPE_SUBNET_INTRA)
 
 # Deployment persistent storage, relative
 DCAPE_VAR=$(DCAPE_VAR)

--- a/apps/portainer/docker-compose.inc.yml
+++ b/apps/portainer/docker-compose.inc.yml
@@ -5,7 +5,9 @@
     labels:
       - "dcape.traefik.tag=${DCAPE_TAG}"
       - "traefik.enable=true"
-      - "traefik.http.routers.portainer.rule=Host(`${PORTAINER_HOST}`)"
+      - "traefik.http.routers.portainer.rule=Host(`${DCAPE_HOST}`) && PathPrefix(`/port/`)"
+      - "traefik.http.middlewares.portainer-prefix.stripprefix.prefixes=/port"
+      - "traefik.http.routers.portainer.middlewares=portainer-prefix@docker"
       - "traefik.http.services.portainer.loadbalancer.server.port=9000"
     volumes:
       - /etc/timezone:/etc/timezone:ro

--- a/apps/traefik/docker-compose.inc.yml
+++ b/apps/traefik/docker-compose.inc.yml
@@ -26,6 +26,7 @@
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./${DCAPE_VAR}/traefik:/etc/traefik
     networks:
+      intra:
       default:
         aliases:
           - ${TRAEFIK_ALIAS}

--- a/apps/traefik/docker-compose.inc.yml
+++ b/apps/traefik/docker-compose.inc.yml
@@ -13,6 +13,11 @@
       - "traefik.http.routers.dashboard.middlewares=narra"
       - "traefik.http.routers.ping.rule=Host(`${DCAPE_HOST}`) && PathPrefix(`/ping`)"
       - "traefik.http.routers.ping.service=ping@internal"
+      # HSTS basic settings for shared using (like Nextcloud required and etc.).
+      - "traefik.http.middlewares.hsts.headers.stsSeconds=15552000"
+      - "traefik.http.middlewares.hsts.headers.stsIncludeSubdomains=true"
+      - "traefik.http.middlewares.hsts.headers.stsPreload=true"
+      - "traefik.http.middlewares.hsts.headers.forceSTSHeader=true"
     env_file:
       - ${DCAPE_VAR}/traefik/traefik.env
     volumes:

--- a/docker-compose.inc.yml
+++ b/docker-compose.inc.yml
@@ -12,6 +12,7 @@ networks:
 
   intra:
     driver: bridge
+    internal: true
     name: ${DCAPE_NET_INTRA}
     driver_opts:
       com.docker.network.bridge.name: ${DCAPE_NET_INTRA}

--- a/docker-compose.inc.yml
+++ b/docker-compose.inc.yml
@@ -10,12 +10,24 @@ networks:
       config:
         - subnet: ${DCAPE_SUBNET}
 
+  intra:
+    driver: bridge
+    name: ${DCAPE_NET_INTRA}
+    driver_opts:
+      com.docker.network.bridge.name: ${DCAPE_NET_INTRA}
+    ipam:
+      config:
+        - subnet: ${DCAPE_SUBNET_INTRA}
+
 services:
 
   # ------------------------------------------------------------------------------
   db:
     image: ${PG_IMAGE}
     restart: always
+    networks:
+      - default
+      - intra
     ports:
       - "127.0.0.1:${PG_PORT_LOCAL}:5432"
     labels:


### PR DESCRIPTION
Для уёбищных "приложений" типа wordpress надо закрыть доступ наружу, чтобы когда их сломают, не участвовали в ботнетах.