### PR TITLE
Preffered using .tar instead .tgz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,10 +226,13 @@ docker-wait:
 define IMPORT_SCRIPT
 [[ "$$DCAPE_DB_DUMP_DEST" ]] || { echo "DCAPE_DB_DUMP_DEST not set. Exiting" ; exit 1 ; } ; \
 DB_NAME="$$1" ; DB_USER="$$2" ; DB_PASS="$$3" ; DB_SOURCE="$$4" ; \
-dbsrc=$$DCAPE_DB_DUMP_DEST/$$DB_SOURCE.tgz ; \
-if [ -f $$dbsrc ] ; then \
-  echo "Dump file $$dbsrc found, restoring database..." ; \
-  zcat $$dbsrc | PGPASSWORD=$$DB_PASS pg_restore -h localhost -U $$DB_USER -O -Ft -d $$DB_NAME || exit 1 ; \
+dbsrc=$$DCAPE_DB_DUMP_DEST/$$DB_SOURCE ; \
+if [ -f $${dbsrc}.tar ] ; then \
+  echo "Prefer dump file $${dbsrc}.tar found, restoring database..." ; \
+  PGPASSWORD=$$DB_PASS pg_restore -h localhost -U $$DB_USER -O -d $$DB_NAME $${dbsrc}.tar || exit 1 ; \
+elif [ -f $${dbsrc}.tgz ] ; then \
+  echo "Dump file $${dbsrc}.tgz found, restoring database..." ; \
+  zcat $${dbsrc}.tgz | PGPASSWORD=$$DB_PASS pg_restore -h localhost -U $$DB_USER -O -Ft -d $$DB_NAME || exit 1 ; \
 else \
   echo "Dump file $$dbsrc not found" ; \
   exit 2 ; \

--- a/apps/drone/dcape-app/Makefile
+++ b/apps/drone/dcape-app/Makefile
@@ -139,12 +139,13 @@ define IMPORT_SCRIPT
 [ "$$DCAPE_DB_DUMP_DEST" ] || { echo "DCAPE_DB_DUMP_DEST not set. Exiting" ; exit 1 ; } ; \
 DB_NAME="$$1" ; DB_USER="$$2" ; DB_PASS="$$3" ; DB_SOURCE="$$4" ; \
 dbsrc=$$DCAPE_DB_DUMP_DEST/$$DB_SOURCE ; \
-if [ -f $${dbsrc}.tgz ] ; then \
+if [ -f $${dbsrc}.tar ] ; then \
+  echo "Prefer dump file $${dbsrc}.tar found, restoring database..." ; \
+  PGPASSWORD=$$DB_PASS pg_restore -h localhost -U $$DB_USER -O -d $$DB_NAME $${dbsrc}.tar || exit 1 ; \
+elif [ -f $${dbsrc}.tgz ] ; then \
   echo "Dump file $${dbsrc}.tgz found, restoring database..." ; \
   zcat $${dbsrc}.tgz | PGPASSWORD=$$DB_PASS pg_restore -h localhost -U $$DB_USER -O -Ft -d $$DB_NAME || exit 1 ; \
-elif [ -f $${dbsrc}.tar ] ; then \
-  echo "Dump file $${dbsrc}.tar found, restoring database..." ; \
-  PGPASSWORD=$$DB_PASS pg_restore -h localhost -U $$DB_USER -O -d $$DB_NAME $${dbsrc}.tar || exit 1 ; \
+
 else \
   echo "Dump file $$dbsrc not found" ; \
   exit 2 ; \

--- a/apps/drone/dcape-app/Makefile
+++ b/apps/drone/dcape-app/Makefile
@@ -102,7 +102,7 @@ down: dc
 dc: $(DCAPE_APP_DC_YML)
 	@echo $(APP_TAG)
 	@[ "$(DCAPE_DC_USED)" != true ] || args="-f $(DCAPE_DC_YML)" ; \
-  docker run --rm  -i \
+  docker run --rm  -t -i \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v $$PWD:$$PWD -w $$PWD \
   -e DCAPE_TAG -e DCAPE_NET -e APP_ROOT -e APP_TAG \


### PR DESCRIPTION
Изменение поведения восстановления из архива. При наличии .tar предпочительно использовать его вместо .tgz

З.Ы. я не знаю как убрать эти "лишние" коммиты в хистори. По факту изменения только Makefile drone/dcape-app